### PR TITLE
Adding file specs to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # EHW-MergeUnsavedNPPFiles
+
+Field | Data
+--- | ---
+| Repo Name: | EHW-MergeUnsavedNPPFiles  |
+| File Name: | ehCode_perl_concatdirs_2017_01.pl |
+| Date Created: | 10/05/15 |
+| Date Modified: | 02/13/17  |
+| Programmer: | Eric Hepperle |
+| Purpose: | Get all files in dir and concat them together, adding a filename to the top of each new section. This is most useful when archiving open but unsaved NotePad++ files. |
+| Usage: | Run in Perl (May only work in GitBash Perl, but not sure) from command line |
+| URL: | https://github.com/codewizard13/EHW-MergeUnsavedNPPFiles |


### PR DESCRIPTION
Adds and formats (with markdown) specs for file ehCode_perl_concatdirs_2017_01.pl.